### PR TITLE
Point bower to Ember.js S3 for build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Computed Propery Macros for Ember.js",
   "main": [ "index.js" ],
   "dependencies": {
-    "ember": "http://builds.emberjs.com/ember-1.0.0-rc.7.js"
+    "ember": "http://builds.emberjs.com/release/ember.js"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Per stefanpenner/ember-app-kit#60 we no longer need to rely on the components repo to stay up-to-date.
