### PR TITLE
Get specs running on ember_09 branch

### DIFF
--- a/spec/suite.html
+++ b/spec/suite.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../components/jquery/jquery.js"></script>
-    <script src="../components/handlebars/handlebars.runtime.js"></script>
+    <script src="../bower_components/jquery/jquery.js"></script>
+    <script src="../bower_components/handlebars/handlebars.runtime.js"></script>
     <script src="../vendor/ember.js"></script>
     <script src="../index.js"></script>
     <link rel="stylesheet" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />


### PR DESCRIPTION
Fixing this sadness:

```
shajith:~/code/ember-cpm (shajith/09_test)$ make
./node_modules/jshint/bin/jshint index.js spec/*Spec.js
./node_modules/bower/bin/bower install
./node_modules/bower/bin/bower install
./node_modules/mocha-phantomjs/bin/mocha-phantomjs spec/suite.html
WARNING: Computed properties will soon be cacheable by default. To enable this in your app, set `ENV.CP_DEFAULT_CACHEABLE = true`.
Error: assertion failed: Ember Views require jQuery 1.6 or 1.7

  file:///Users/shajith/code/ember-cpm/vendor/ember.js:45
  file:///Users/shajith/code/ember-cpm/vendor/ember.js:12096
  file:///Users/shajith/code/ember-cpm/vendor/ember.js:12099
make: *** [test] Error 1
```
