### PR TITLE
Update Bower dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ jshint_bin     = ./node_modules/jshint/bin/jshint
 phantomjs_bin  = ./node_modules/mocha-phantomjs/bin/mocha-phantomjs
 bower_bin      = ./node_modules/bower/bin/bower
 
-bower_libs = bower_components/ember/index.js bower_components/jquery/index.js bower_components/handlebars/index.js
+bower_libs = bower_components/ember/ember.js bower_components/jquery/jquery.js bower_components/handlebars/handlebars.runtime.js
 npm_libs   = $(jshint_bin) $(phantomjs_bin) $(bower_bin)
 src_files = src/preamble.js src/index.js src/concat.js
 

--- a/bower.json
+++ b/bower.json
@@ -6,9 +6,9 @@
     "index.js"
   ],
   "dependencies": {
-    "ember": "http://builds.emberjs.com/release/ember.js",
-    "jquery": "http://code.jquery.com/jquery-1.10.2.js",
-    "handlebars": "https://raw.github.com/wycats/handlebars.js/1.0.0/dist/handlebars.runtime.js"
+    "ember": "1.2.0",
+    "jquery": "~>1.10",
+    "handlebars": "1.1.2"
   },
   "scripts": {
     "test": "make test"

--- a/spec/suite.html
+++ b/spec/suite.html
@@ -1,9 +1,9 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../bower_components/jquery/index.js"></script>
-    <script src="../bower_components/handlebars/index.js"></script>
-    <script src="../bower_components/ember/index.js"></script>
+    <script src="../bower_components/jquery/jquery.js"></script>
+    <script src="../bower_components/handlebars/handlebars.runtime.js"></script>
+    <script src="../bower_components/ember/ember.js"></script>
     <script src="../index.js"></script>
     <link rel="stylesheet" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
   </head>


### PR DESCRIPTION
Use specific versions of Ember and Handlebars, and jQuery ~> 1.10. All from
the main Bower registry.

Resolves #14.
