### PR TITLE
Add "service" macro

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,12 @@
     return new Handlebars.SafeString(value);
   });
 
+  registerComputed('service', function(controllerName) {
+    var container = this.get('container');
+    if (container == null) { return null; }
+    return container.lookup('service:' + controllerName);
+  });
+
   EmberCPM.Macros.fmt = function() {
     var formatString = '' + a_slice.call(arguments, -1),
         properties   = a_slice.call(arguments, 0, -1),

--- a/spec/serviceSpec.js
+++ b/spec/serviceSpec.js
@@ -1,0 +1,19 @@
+describe('service', function () {
+
+  var subject;
+
+  beforeEach(function() {
+    var container = new Ember.Container();
+    container.register('service:log', 'the logging service', { instantiate: false });
+
+    subject = Ember.Object.extend({
+      container: container,
+      log: EmberCPM.Macros.service('log')
+    }).create();
+  });
+
+  it('asks the container to resolve the given service', function() {
+    expect(subject.get('log')).to.equal('the logging service');
+  });
+
+});

--- a/spec/suite.html
+++ b/spec/suite.html
@@ -32,6 +32,7 @@
     <script src="./installSpec.js"></script>
     <script src="./joinSpec.js"></script>
     <script src="./concatSpec.js"></script>
+    <script src="./serviceSpec.js"></script>
     <script>
       if (window.mochaPhantomJS) { mochaPhantomJS.run(); }
       else { mocha.run(); }


### PR DESCRIPTION
This macro lets object look up services from the container. It offers an alternative to `needs` and `Ember.Container.prototype.injection`.

The weakness of `needs` is that it is somewhat cumbersome. Declaring

```
needs: [ "posts" ]
```

will add support for `this.get('controllers.posts')`. A standard practice is to alias that to `posts`, but that essentially means declaring the dependency twice.

The weakness of `Ember.Container.prototype.injection` is that it has to be done centrally. That's great for very generic things like injecting the current user into _all_ controllers. It's not so nice when you need to connect just a couple out of your dozens or hundreds of controllers.

It would be easy to add a "fromContainer" macro to allow objects to look up arbitrary dependencies from the container. That, however, leads to spaghetti code. The intent of this macro is limited to making it easy to look up central services from wherever they are needed.
