### PR TITLE
Add phantomjs as a development dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mocha-phantomjs": "~2.0.1",
     "jshint": "~2.0.1",
     "handlebars": "~1.0.11",
-    "bower": "~1.2.6"
+    "bower": "~1.2.6",
+    "phantomjs": "~1.9"
   }
 }


### PR DESCRIPTION
I was trying to make a PR but when I run `make` I got this meaningless error:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:988:11)
    at Process.ChildProcess._handle.onexit (child_process.js:779:34)
```

I tried updating node/npm/bower without success. Then I got a hunch,
and I installed manually all the things. The problem was phantomjs.

Apparently, `mocha-phantomjs` does not install phantomjs as a dependecy
(maybe is a mocha-phantom bug).
Anyway, now it is an explicit dependency. It won't hurt.

I set version "~1.9". Probably order ones will work, but I haven't tried.
