### PR TITLE
Remove check for getPath from master branch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,7 @@
   }
 
   var a_slice  = Array.prototype.slice,
-      get = (function() {
-        var getSupportsPaths = Ember.get({ nested: { value: true } }, 'nested.value');
-        return getSupportsPaths ? Ember.get : Ember.getPath;
-      })();
+      get = Ember.get;
 
   function registerComputed(name, macro) {
     EmberCPM.Macros[name] = function(dependentKey) {
@@ -157,11 +154,7 @@
 (function(window, Ember, $, EmberCPM) {
   var a_slice  = Array.prototype.slice,
       a_forEach = Ember.ArrayPolyfills.forEach,
-      get = (function() {
-        var getSupportsPaths = Ember.get({ nested: { value: true } }, 'nested.value');
-        return getSupportsPaths ? Ember.get : Ember.getPath;
-      })();
-
+      get = Ember.get;
 
   /*
      Returns the index where an item is to be removed from, or placed into, for

--- a/src/concat.js
+++ b/src/concat.js
@@ -1,11 +1,7 @@
 (function(window, Ember, $, EmberCPM) {
   var a_slice  = Array.prototype.slice,
       a_forEach = Ember.ArrayPolyfills.forEach,
-      get = (function() {
-        var getSupportsPaths = Ember.get({ nested: { value: true } }, 'nested.value');
-        return getSupportsPaths ? Ember.get : Ember.getPath;
-      })();
-
+      get = Ember.get;
 
   /*
      Returns the index where an item is to be removed from, or placed into, for

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,7 @@
   }
 
   var a_slice  = Array.prototype.slice,
-      get = (function() {
-        var getSupportsPaths = Ember.get({ nested: { value: true } }, 'nested.value');
-        return getSupportsPaths ? Ember.get : Ember.getPath;
-      })();
+      get = Ember.get;
 
   function registerComputed(name, macro) {
     EmberCPM.Macros[name] = function(dependentKey) {


### PR DESCRIPTION
Ember.get and Ember.getPath have been unified in July of 2012.
I think that we should not check for a method that has gone 18 months ago
outside of the 0.9 branch.
