### PR TITLE
Use locally installed jshint in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ensure_phantomjs:
 	@which phantomjs > /dev/null || (echo "Couldn't find phantomjs" && false)
 
 jshint: $(jshint_bin)
-	@jshint Brocfile.js src/*.js spec/*Spec.js
+	@$(jshint_bin) Brocfile.js src/*.js spec/*Spec.js
 	@echo "JSHint OK"
 
 pristine: clean


### PR DESCRIPTION
I am by no means a Make expert, but without this change I could not run `make build` (it couldn't find `jshint` since I do not have it installed globally).
