### PR TITLE
Add ember-cli addon.

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'ember-cpm',
+
+  init: function() {
+    this.treePaths['addon'] = 'src';
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "licence": "APLv2 / MIT",
   "description": "Computed Propery Macros for Ember.js",
   "keywords": [
-    "ember"
+    "ember",
+    "ember-addon"
   ],
   "author": "James A. Rosen <james.a.rosen@gmail.com>",
   "repository": {
@@ -14,6 +15,9 @@
   "main": "dist/cjs/ember-cpm.js",
   "scripts": {
     "test": "make test-ci"
+  },
+  "ember-addon": {
+    "main": "ember-addon-main.js"
   },
   "devDependencies": {
     "bower": "~1.3.3",


### PR DESCRIPTION
Once published to NPM (or just referenced from git) ember-cpm can be consumed by an ember-cli addon with only `npm install --save-dev ember-cpm`.

Since our `src/` directory is native ES6 modules, the following works as expected (from within an ember-cli app):

``` javascript
import ifNull from 'ember-cpm/if-null';
```

For reference: https://github.com/cibernox/ember-cpm-cli-test-app/pull/2
