### PR TITLE
Testing s3 publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,13 @@ install:
 
 script:
   - npm test
+
+after_success:
+  - npm build
+  - "./s3-publish.js"
+
+env:
+  global:
+    - S3_BUCKET_NAME=ember-cpm-builds
+
+

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-inject-live-reload": "^1.2.2",
     "ember-cli-qunit": "0.1.0",
     "ember-data": "1.0.0-beta.10",
+    "ember-publisher": "0.0.7",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },

--- a/s3-config.js
+++ b/s3-config.js
@@ -1,0 +1,21 @@
+module.exports = function(revision, tag, date){
+  var names = ['ember-cpm-latest.js', 'ember-cpm-' + revision + '.js'];
+  if (tag) {
+    names.push('ember-cpm-' + tag + '.js')
+  }
+  return {
+    'named-amd/ember-cpm.js': {
+      contentType: 'text/javascript',
+      destinations: {
+        canary: names.map(function(name) { return 'named-amd/' + name })
+      }
+    },
+
+    'globals/ember-cpm.js': {
+      contentType: 'text/javascript',
+      destinations: {
+        canary: names.map(function(name) { return 'globals/' + name })
+      }
+    }
+  };
+};

--- a/s3-publish.js
+++ b/s3-publish.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// To invoke this from the commandline you need the following to env vars to exist:
+//
+// S3_BUCKET_NAME
+// TRAVIS_BRANCH
+// TRAVIS_TAG
+// TRAVIS_COMMIT
+// S3_SECRET_ACCESS_KEY
+// S3_ACCESS_KEY_ID
+//
+var S3Publisher = require('ember-publisher');
+var configPath = require('path').join(__dirname, './s3-config.js');
+
+publisher = new S3Publisher({projectConfigPath: configPath});
+publisher.publish();


### PR DESCRIPTION
This is an attempt to automatically upload to S3 global and named-amd versions of the library on each successful build in travis.

The idea is eventually add to the gitignore the `/dist` folder, to avoid the need to build before commiting, and also remove noise from PRs.

I've configured credentials to a personal bucket for now.
