### PR TITLE
Deprecate sumBy macro

### DIFF
--- a/addon/macros/sum-by.js
+++ b/addon/macros/sum-by.js
@@ -3,15 +3,52 @@ import Ember from 'ember';
 var get = Ember.get;
 var reduceComputed = Ember.reduceComputed;
 
+function logWarning(typeName, propName) {
+  var message = '[DEPRECATED: EmberCPM/sumBy] - %@ - %@'.fmt(typeName, propName);
+  if (console.groupCollapsed) {
+    // modern browsers
+    console.groupCollapsed(message);
+    console.info('Please use a combination of EmberCPM.Macros.sum and EmberCPM.Macros.mapBy');
+    console.info('EmberCPM.Macros.sum(EmberCPM.Macros.mapBy("list", "value"))');
+    if (console.trace) {
+      console.trace();
+    }
+    console.groupEnd();
+  }
+  else {
+    // legacy browsers
+    Ember.Logger.warn(message);
+  }
+}
+
+/**
+ * DEPRECATED - 10/14/2014
+ * Rather than use sumBy, developers should use composed computed property macros
+ *
+ * OLD WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sumBy('list', 'val')
+ * }
+ *
+ * NEW WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sum(mapBy('list', 'val'))
+ * }
+ */
+
 export default function EmberCPM_sumBy(dependentKey, propertyKey) {
   return reduceComputed(dependentKey + '.@each.' + propertyKey, {
     initialValue: 0.0,
 
     addedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue + parseFloat(get(item, propertyKey));
     },
 
     removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue - parseFloat(get(item, propertyKey));
     }
   });

--- a/dist/amd/macros/sum-by.js
+++ b/dist/amd/macros/sum-by.js
@@ -7,15 +7,52 @@ define(
     var get = Ember.get;
     var reduceComputed = Ember.reduceComputed;
 
+    function logWarning(typeName, propName) {
+      var message = '[DEPRECATED: EmberCPM/sumBy] - %@ - %@'.fmt(typeName, propName);
+      if (console.groupCollapsed) {
+        // modern browsers
+        console.groupCollapsed(message);
+        console.info('Please use a combination of EmberCPM.Macros.sum and EmberCPM.Macros.mapBy');
+        console.info('EmberCPM.Macros.sum(EmberCPM.Macros.mapBy("list", "value"))');
+        if (console.trace) {
+          console.trace();
+        }
+        console.groupEnd();
+      }
+      else {
+        // legacy browsers
+        Ember.Logger.warn(message);
+      }
+    }
+
+    /**
+     * DEPRECATED - 10/14/2014
+     * Rather than use sumBy, developers should use composed computed property macros
+     *
+     * OLD WAY
+     * {
+     *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+     *   listValSum: sumBy('list', 'val')
+     * }
+     *
+     * NEW WAY
+     * {
+     *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+     *   listValSum: sum(mapBy('list', 'val'))
+     * }
+     */
+
     __exports__["default"] = function EmberCPM_sumBy(dependentKey, propertyKey) {
       return reduceComputed(dependentKey + '.@each.' + propertyKey, {
         initialValue: 0.0,
 
         addedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+          logWarning(this.constructor.toString(), dependentKey);
           return accumulatedValue + parseFloat(get(item, propertyKey));
         },
 
         removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+          logWarning(this.constructor.toString(), dependentKey);
           return accumulatedValue - parseFloat(get(item, propertyKey));
         }
       });

--- a/dist/cjs/macros/sum-by.js
+++ b/dist/cjs/macros/sum-by.js
@@ -4,15 +4,52 @@ var Ember = require("ember")["default"] || require("ember");
 var get = Ember.get;
 var reduceComputed = Ember.reduceComputed;
 
+function logWarning(typeName, propName) {
+  var message = '[DEPRECATED: EmberCPM/sumBy] - %@ - %@'.fmt(typeName, propName);
+  if (console.groupCollapsed) {
+    // modern browsers
+    console.groupCollapsed(message);
+    console.info('Please use a combination of EmberCPM.Macros.sum and EmberCPM.Macros.mapBy');
+    console.info('EmberCPM.Macros.sum(EmberCPM.Macros.mapBy("list", "value"))');
+    if (console.trace) {
+      console.trace();
+    }
+    console.groupEnd();
+  }
+  else {
+    // legacy browsers
+    Ember.Logger.warn(message);
+  }
+}
+
+/**
+ * DEPRECATED - 10/14/2014
+ * Rather than use sumBy, developers should use composed computed property macros
+ *
+ * OLD WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sumBy('list', 'val')
+ * }
+ *
+ * NEW WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sum(mapBy('list', 'val'))
+ * }
+ */
+
 exports["default"] = function EmberCPM_sumBy(dependentKey, propertyKey) {
   return reduceComputed(dependentKey + '.@each.' + propertyKey, {
     initialValue: 0.0,
 
     addedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue + parseFloat(get(item, propertyKey));
     },
 
     removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue - parseFloat(get(item, propertyKey));
     }
   });

--- a/dist/globals/ember-cpm.js
+++ b/dist/globals/ember-cpm.js
@@ -567,15 +567,52 @@ var Ember = window.Ember["default"] || window.Ember;
 var get = Ember.get;
 var reduceComputed = Ember.reduceComputed;
 
+function logWarning(typeName, propName) {
+  var message = '[DEPRECATED: EmberCPM/sumBy] - %@ - %@'.fmt(typeName, propName);
+  if (console.groupCollapsed) {
+    // modern browsers
+    console.groupCollapsed(message);
+    console.info('Please use a combination of EmberCPM.Macros.sum and EmberCPM.Macros.mapBy');
+    console.info('EmberCPM.Macros.sum(EmberCPM.Macros.mapBy("list", "value"))');
+    if (console.trace) {
+      console.trace();
+    }
+    console.groupEnd();
+  }
+  else {
+    // legacy browsers
+    Ember.Logger.warn(message);
+  }
+}
+
+/**
+ * DEPRECATED - 10/14/2014
+ * Rather than use sumBy, developers should use composed computed property macros
+ *
+ * OLD WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sumBy('list', 'val')
+ * }
+ *
+ * NEW WAY
+ * {
+ *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+ *   listValSum: sum(mapBy('list', 'val'))
+ * }
+ */
+
 exports["default"] = function EmberCPM_sumBy(dependentKey, propertyKey) {
   return reduceComputed(dependentKey + '.@each.' + propertyKey, {
     initialValue: 0.0,
 
     addedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue + parseFloat(get(item, propertyKey));
     },
 
     removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+      logWarning(this.constructor.toString(), dependentKey);
       return accumulatedValue - parseFloat(get(item, propertyKey));
     }
   });

--- a/dist/named-amd/ember-cpm.js
+++ b/dist/named-amd/ember-cpm.js
@@ -629,15 +629,52 @@ define("ember-cpm/macros/sum-by",
     var get = Ember.get;
     var reduceComputed = Ember.reduceComputed;
 
+    function logWarning(typeName, propName) {
+      var message = '[DEPRECATED: EmberCPM/sumBy] - %@ - %@'.fmt(typeName, propName);
+      if (console.groupCollapsed) {
+        // modern browsers
+        console.groupCollapsed(message);
+        console.info('Please use a combination of EmberCPM.Macros.sum and EmberCPM.Macros.mapBy');
+        console.info('EmberCPM.Macros.sum(EmberCPM.Macros.mapBy("list", "value"))');
+        if (console.trace) {
+          console.trace();
+        }
+        console.groupEnd();
+      }
+      else {
+        // legacy browsers
+        Ember.Logger.warn(message);
+      }
+    }
+
+    /**
+     * DEPRECATED - 10/14/2014
+     * Rather than use sumBy, developers should use composed computed property macros
+     *
+     * OLD WAY
+     * {
+     *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+     *   listValSum: sumBy('list', 'val')
+     * }
+     *
+     * NEW WAY
+     * {
+     *   list: [{id: 1, val: 5.0}, {id: 2, val: 2.0}],
+     *   listValSum: sum(mapBy('list', 'val'))
+     * }
+     */
+
     __exports__["default"] = function EmberCPM_sumBy(dependentKey, propertyKey) {
       return reduceComputed(dependentKey + '.@each.' + propertyKey, {
         initialValue: 0.0,
 
         addedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+          logWarning(this.constructor.toString(), dependentKey);
           return accumulatedValue + parseFloat(get(item, propertyKey));
         },
 
         removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
+          logWarning(this.constructor.toString(), dependentKey);
           return accumulatedValue - parseFloat(get(item, propertyKey));
         }
       });


### PR DESCRIPTION
Fixes #69 

Here's what the deprecation warning looks like on modern browsers. On older versions of IE, it'll fall back to `Ember.Logger.warn`
![screen shot 2014-10-14 at 1 30 29 am](https://cloud.githubusercontent.com/assets/558005/4626019/fc71f108-537c-11e4-84b8-a405bea7d816.png)
