### PR TITLE
Remove support for zero-argument cases in product, sum macros

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -151,15 +151,14 @@ export function reduceComputedPropertyMacro(reducingFunction, options) {
 
   return function () {
     var mainArguments = Array.prototype.slice.call(arguments); // all arguments
+    Ember.assert('Error: At least one argument is required', mainArguments.length > 0);
+
     var propertyArguments = getDependentPropertyKeys(mainArguments);
 
     propertyArguments.push(function () {
       var self = this;
       switch (mainArguments.length) {
-
-        case 0:   // Handle zero-argument case
-          return 0;
-
+        // case 0:   // We already handle the zero-argument case above
         case 1:   // Handle one-argument case
           return singleItemCallback.call(this, mainArguments[0]);
 

--- a/tests/unit/macros/product-test.js
+++ b/tests/unit/macros/product-test.js
@@ -7,7 +7,6 @@ var MyType = Ember.Object.extend({
   c: product('a', 'b'),
   d: product('a', 'c'),
   e: product('a'),
-  f: product(),
   i: product('a', 'b', 'g', 'h'),
   j: product('a', 'b', 'g', 'h', 2),
   k: product(product('a', 'b'), 'h')
@@ -46,7 +45,11 @@ test('given one argument, returns the value of that property', function () {
 });
 
 test('given no arguments, returns 0', function () {
-  equal(myObj.get('f'), 0);
+  throws(function () {
+    Ember.Object.extend({
+      prop: product()
+    });
+  }, 'Error:');
 });
 
 test('product of product', function () {

--- a/tests/unit/macros/sum-test.js
+++ b/tests/unit/macros/sum-test.js
@@ -9,7 +9,6 @@ var MyType = Ember.Object.extend({
   f: sum('a', 'b', 'c', 2),
   g: sum('a'),
   h: sum(2),
-  i: sum(),
   j: [1, 2, 3, 4],
   k: sum(Ember.computed.max('j'), 5),
   l: sum(sum('a', 'b'), 5),
@@ -36,7 +35,11 @@ test('calculates the sum of two basic numeric properties', function () {
 });
 
 test('returns 0 when passed no arguments', function () {
-  equal(myObj.get('i'), 0);
+  throws(function () {
+    Ember.Object.extend({
+      prop: sum()
+    });
+  }, 'Error:');
 });
 
 test('calculates the sum of three basic numeric properties', function () {


### PR DESCRIPTION
Based on feedback from @cibernox in #81, the zero-argument cases for `sum` and `product` are too clever. When you do the following, errors should be thrown in development mode

``` js
Ember.Object.extend({
  prop: not()
});
```

``` js
Ember.Object.extend({
  prop: product()
});
```

The error thrown is `Error: At least one argument is required`.
