### PR TITLE
asFloat, asInt enhancements

### DIFF
--- a/addon/macros/as-float.js
+++ b/addon/macros/as-float.js
@@ -23,4 +23,6 @@ import {parseComputedPropertyMacro} from '../utils';
   @param value The value to cast. It can be a number, a numeric string or a property key.
   @return {Number} Returns casted float.
 */
-export default parseComputedPropertyMacro(parseFloat);
+export default parseComputedPropertyMacro(function (raw) {
+  return 'boolean' === typeof raw ? (raw ? 1 : 0) : parseFloat(raw); 
+});

--- a/addon/macros/as-int.js
+++ b/addon/macros/as-int.js
@@ -19,9 +19,10 @@ import {parseComputedPropertyMacro} from '../utils';
   ```
 
   @method macros.asInt
-  @param value The value to cast. It can be a numbed, a numeric string or a property key.
+  @for macros
+  @param {Number|String|Boolean} value The value to cast. It can be a numbed, a numeric string or a property key.
   @return {Number} Returns casted integer.
 */
 export default parseComputedPropertyMacro(function (raw) {
-  return parseInt(raw, 10);
+  return 'boolean' === typeof raw ? (raw ? 1 : 0) : parseInt(raw, 10);
 });

--- a/tests/unit/macros/as-float-test.js
+++ b/tests/unit/macros/as-float-test.js
@@ -4,11 +4,14 @@ import asFloat from 'ember-cpm/macros/as-float';
 var MyType = Ember.Object.extend({
   val: '6',
   floatVal: 1.2,
+  boolVal: true,
+  nullVal: null,
+  undefinedVal: undefined,
   valAsFloat: asFloat('val'),
-  nothingAsFloat: asFloat(),
+  nullAsFloat: asFloat('nullValue'),
+  undefinedAsFloat: asFloat('undefinedValue'),
+  boolAsFloat: asFloat('boolVal'),
   floatAsFloat: asFloat('floatVal'),
-  nullAsFloat: asFloat(null),
-  undefinedAsFloat: asFloat(undefined),
   emptyStringAsFloat: asFloat(''),
   nonNumericStringAsFloat: asFloat('abcd')
 });
@@ -43,8 +46,12 @@ test('numeric prop - setting value as a float', function () {
   strictEqual(myObj.get('floatVal'), 12.1);
 });
 
-test('zero argument case', function () {
-  strictEqual(myObj.get('nothingAsFloat').toString(), 'NaN');
+test('null prop - getting value as a float', function () {
+  strictEqual(myObj.get('nullAsFloat').toString(), 'NaN');
+});
+
+test('undefined prop - getting value as a float', function () {
+  strictEqual(myObj.get('undefinedAsFloat').toString(), 'NaN');
 });
 
 test('string argument case', function () {
@@ -52,10 +59,38 @@ test('string argument case', function () {
   equal(myObj.get('emptyStringAsFloat').toString(), 'NaN', 'empty string');
 });
 
-test('null argument case', function () {
-  strictEqual(myObj.get('nullAsFloat').toString(), 'NaN');
+test('Setting float value updates dependant string property', function () {
+  myObj.set('valAsFloat', 3.2);
+  strictEqual(myObj.get('val'), '3.2', 'string type of dependant property is respected');
 });
 
-test('undefined argument case', function () {
-  strictEqual(myObj.get('undefinedAsFloat').toString(), 'NaN');
+test('Setting float value updates dependant numeric property', function () {
+  myObj.set('floatAsFloat', 111.124);
+  strictEqual(myObj.get('floatVal'), 111.124, 'float type of dependant property is respected');
+});
+
+test('boolean argument case', function () {
+  strictEqual(myObj.get('boolAsFloat'), 1.0, 'boolean true evaluates to 1');
+  myObj.set('boolVal', false);
+  strictEqual(myObj.get('boolAsFloat'), 0.0, 'boolean false evaluates to 0');
+  myObj.set('boolAsFloat', 1.0);
+  strictEqual(myObj.get('boolVal'), true);
+  myObj.set('boolAsFloat', 0.0);
+  strictEqual(myObj.get('boolVal'), false);
+});
+
+test('zero-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asFloat()
+    });
+  }, /No\sargument/);
+});
+
+test('null-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asFloat(null)
+    });
+  }, /Null\sargument/);
 });

--- a/tests/unit/macros/as-int-test.js
+++ b/tests/unit/macros/as-int-test.js
@@ -5,14 +5,17 @@ var MyType = Ember.Object.extend({
   val: '6',
   intVal: 2,
   floatVal: 2.6,
+  boolVal: true,
+  nullVal: null,
+  undefinedVal: undefined,
   valAsint: asInt('val'),
-  nothingAsint: asInt(),
+  boolAsInt: asInt('boolVal'),
+  nullAsInt: asInt('nullValue'),
+  undefinedAsInt: asInt('undefinedValue'),
   intValAsInt: asInt('intVal'),
-  nullAsint: asInt(null),
   floatValAsInt: asInt('floatVal'),
   nonNumericStringAsInt: asInt('adas'),
   emptyStringAsInt: asInt(''),
-  undefinedAsint: asInt(undefined)
 });
 
 var myObj;
@@ -49,19 +52,52 @@ test('float prop - getting value as a int', function () {
   strictEqual(myObj.get('floatValAsInt'), 2);
 });
 
+test('null prop - getting value as a int', function () {
+  strictEqual(myObj.get('nullAsInt').toString(), 'NaN');
+});
+
+test('undefined prop - getting value as a int', function () {
+  strictEqual(myObj.get('undefinedAsInt').toString(), 'NaN');
+});
+
 test('string argument case', function () {
   equal(myObj.get('nonNumericStringAsInt').toString(), 'NaN', 'non-numeric string');
   equal(myObj.get('emptyStringAsInt').toString(), 'NaN', 'empty string');
 });
 
-test('zero argument case', function () {
-  strictEqual(myObj.get('nothingAsint').toString(), 'NaN');
+test('boolean argument case', function () {
+  strictEqual(myObj.get('boolAsInt'), 1, 'boolean true evaluates to 1');
+  myObj.set('boolVal', false);
+  strictEqual(myObj.get('boolAsInt'), 0, 'boolean false evaluates to 0');
+  myObj.set('boolAsInt', 1);
+  strictEqual(myObj.get('boolVal'), true);
+  myObj.set('boolAsInt', 0);
+  strictEqual(myObj.get('boolVal'), false);
 });
 
-test('null argument case', function () {
-  strictEqual(myObj.get('nullAsint').toString(), 'NaN');
+test('Setting int value updates dependant string property', function () {
+  myObj.set('valAsint', 3);
+  strictEqual(myObj.get('val'), '3', 'string type of dependant property is respected');
 });
 
-test('undefined argument case', function () {
-  strictEqual(myObj.get('undefinedAsint').toString(), 'NaN');
+test('Setting int value updates dependant int property', function () {
+  myObj.set('intValAsInt', 111);
+  strictEqual(myObj.get('intVal'), 111, 'int type of dependant property is respected');
+});
+
+
+test('zero-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asInt()
+    });
+  }, /No\sargument/);
+});
+
+test('null-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asInt(null)
+    });
+  }, /Null\sargument/);
 });


### PR DESCRIPTION
A combination of a few bug fixes, additional tests, and a minor enhancement
### Enhancements
- boolean properties are now handled by asInt, asFloat. `true` maps to 1, `false` maps to 0
### Fixes
- I have removed support for null and undefined arguments to the asInt, asFloat CPMs. Exceptions are now thrown for either of these cases.
- Fixed the "setter" logic for `parseComputedPropertyMacro`. It was reusing the `parseFunction` callback inappropriately, instead of using an appropriate transformation based on dependent property type.
### Test Coverage
- Added coverage to `asInt` and `asFloat` for properties with `undefined` and `null` values
- Added coverage to `asInt` and `asFloat` for setting values, and verifying that appropriate updates to dependent properties happen
- Added coverage to `asInt` and `asFloat` for `undefined` and `null` property keys (verifies exceptions are thrown)
- Added coverage to `asInt` and `asFloat` for the aforementioned boolean value support  
