### PR TITLE
asString - useful for binding to UI elements that deal only in strings

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -23,6 +23,7 @@ import difference from './macros/difference';
 import not from './macros/not';
 import asFloat from './macros/as-float';
 import asInt from './macros/as-int';
+import asString from './macros/as-string';
 
 function reverseMerge(dest, source) {
   for (var key in source) {
@@ -34,6 +35,7 @@ function reverseMerge(dest, source) {
 
 var VERSION = '1.3.0';
 var Macros = {
+  asString: asString,
   not: not,
   among: among,
   allEqual: allEqual,

--- a/addon/macros/as-string.js
+++ b/addon/macros/as-string.js
@@ -1,0 +1,39 @@
+/**
+  EmberCPM Macros
+
+  @module macros
+  @requires ember, utils
+*/
+
+import {parseComputedPropertyMacro} from '../utils';
+
+/**
+  Provide a writable property that's a string representation
+  of some dependant
+
+  Example
+
+  ````javascript
+  var Square = Ember.Object.extend({
+    sideLength: 4,
+    sideLengthAsString: asString('sideLength')
+  });
+  ````
+  ````handlebars
+  {{!--
+    Bind this input to the writable string binding
+    so that the numeric 'sideLength' property will remain
+    an integer. (HTML inputs always have string values)
+   --}}
+  {{input type="text" value='sideLengthAsString'}}
+  ````
+
+  @method macros.asString
+  @for macros
+  @param {Number|String|Boolean} key dependant property key
+  @return {String} string representation of another property
+*/
+
+export default parseComputedPropertyMacro(function EmberCPM_asString (raw) {
+  return '' + raw;
+});

--- a/tests/unit/macros/as-string-test.js
+++ b/tests/unit/macros/as-string-test.js
@@ -1,0 +1,62 @@
+import Ember from 'ember';
+import asString from 'ember-cpm/macros/as-string';
+
+var MyType = Ember.Object.extend({
+  asStringProp: asString('val')
+});
+
+var myObj;
+
+module('asString', {
+  setup: function () {
+    myObj = MyType.create({
+      val: 6
+    });
+  }
+});
+
+test('Get a value as a string', function () {
+  strictEqual(myObj.get('asStringProp'), '6');
+});
+
+test('Respond to changes in dependent property', function () {
+  myObj.set('val', 4);
+  strictEqual(myObj.get('asStringProp'), '4');
+});
+
+test('setting string property should update dependent int property', function () {
+  myObj.set('asStringProp', '12');
+  strictEqual(myObj.get('val'), 12, 'int type of dependant property is respected');
+});
+
+test('setting string property should update dependent string property', function () {
+  myObj = MyType.create({
+    val: '11'
+  });
+  myObj.set('asStringProp', '12');
+  strictEqual(myObj.get('val'), '12', 'string type of dependant property is respected');
+});
+
+test('setting string property should update dependent string property', function () {
+  myObj = MyType.create({
+    val: true
+  });
+  myObj.set('asStringProp', 'false');
+  strictEqual(myObj.get('val'), false, 'boolean type of dependant property is respected');
+});
+
+test('zero-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asString()
+    });
+  }, /No\sargument/);
+});
+
+test('null-argument case throws an exception', function () {
+  throws(function () {
+    Ember.Object.extend({
+      prop: asString(null)
+    });
+  }, /Null\sargument/);
+});


### PR DESCRIPTION
The most compelling use case for this macro is as follows

``` javascript
export default Ember.Controller.extend({
   age: 26,
   ageAsString: asString('age')
});
```

**Scenario w/o `asString`**
We bind to the "age" property. Since HTML inputs deal only
in strings, when the user types in this text box, the value of the "age"
property will be updated with a string value (changing its type)

In this case, "age" changes from a numeric value to a string value

``` handlebars
{{input type="text" value="age"}}
```

**Scenario w/ `asString`**
We bind to the "ageAsString" property. The HTML input updates
the "ageAsString" property when the user types in the text box, and
the value of the "age" property is updated (and it's type is respected).

In this case, "age" remains a numeric value.

``` handlebars
{{input type="text" value="ageAsString"}}
```
#### Dependent on
#92 :white_check_mark:
