### PR TITLE
Fmt - support for composeable CPMs

### DIFF
--- a/addon/macros/fmt.js
+++ b/addon/macros/fmt.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
+import {getVal, getDependentPropertyKeys} from '../utils';
 
-var get = Ember.get;
 var computed = Ember.computed;
 var EmberString = Ember.String;
 
@@ -28,15 +28,20 @@ var a_slice = Array.prototype.slice;
   @return The formatted string.
 */
 export default function EmberCPM_fmt() {
-  var formatString = '' + a_slice.call(arguments, -1),
-      properties   = a_slice.call(arguments, 0, -1),
-      propertyArguments = a_slice.call(arguments, 0 , -1);
+  var mainArguments = a_slice.call(arguments);
+  var propertyArguments = getDependentPropertyKeys(mainArguments)
+    // Don't regard a format string literal as a dependant property key
+    .reject(function (val) {
+      return val.indexOf('%@') !== -1;
+    });
 
   propertyArguments.push(function(){
+    var formatString = getVal.call(this, mainArguments[mainArguments.length - 1]);
+
     var values = [], i, value;
 
-    for (i = 0; i < properties.length; ++i) {
-      value = get(this, properties[i]);
+    for (i = 0; i < mainArguments.length - 1; i++) {
+      value = getVal.call(this, mainArguments[i], false);
       if (value === undefined) { return undefined; }
       if (value === null)      { return null; }
       values.push(value);

--- a/addon/macros/fmt.js
+++ b/addon/macros/fmt.js
@@ -38,16 +38,18 @@ export default function EmberCPM_fmt() {
   propertyArguments.push(function(){
     var formatString = getVal.call(this, mainArguments[mainArguments.length - 1]);
 
-    var values = [], i, value;
+    var values = [];
+    var undefinedValueFound = false;
+    var nullValueFound = false;
 
-    for (i = 0; i < mainArguments.length - 1; i++) {
-      value = getVal.call(this, mainArguments[i], false);
-      if (value === undefined) { return undefined; }
-      if (value === null)      { return null; }
+    for (var i = 0; i < mainArguments.length - 1; i++) {
+      var value = getVal.call(this, mainArguments[i], false);
+      if (value === undefined) { undefinedValueFound = true; break; }
+      if (value === null)      { nullValueFound = true; }
       values.push(value);
     }
 
-    return EmberString.fmt(formatString, values);
+    return undefinedValueFound ? undefined : (nullValueFound ? null : EmberString.fmt(formatString, values));
   });
 
   return computed.apply(this, propertyArguments);

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -68,10 +68,12 @@ export function getDependentPropertyKeys(argumentArr) {
  @method getVal
  @param val value to evaluate
  */
-export function getVal(val) {
+export function getVal(val, implicitLiteral) {
   if (Ember.typeOf(val) === 'string') {
+    // Are strings that we identify as NOT property keys to be regarded as string literals?
+    var literalsAreImplicit = implicitLiteral === false ? false : true;
     var propVal = Ember.get(this, val);
-    return  'undefined' === typeof propVal ? val : propVal;
+    return  'undefined' === typeof propVal ? (literalsAreImplicit ? val : undefined) : propVal;
   } else if (Ember.typeOf(val) === 'object' && Ember.Descriptor === val.constructor) {
     return val.altKey ? this.get(val.altKey) : val.func.apply(this);
   } else {

--- a/tests/unit/macros/fmt-test.js
+++ b/tests/unit/macros/fmt-test.js
@@ -26,11 +26,17 @@ test('injects the value into the format-string', function() {
 test('returns undefined if *any* of the values is undefined', function() {
   var o = MyObj.create({ label: "Name" });
   strictEqual(o.get('labeled'), undefined);
+  var oo = MyObj.create({ label: null });
+  strictEqual(oo.get('labeled'), undefined);
+  var ooo = MyObj.create({ value: '123' });
+  strictEqual(ooo.get('labeled'), undefined);
 });
 
 test('returns null if *any* of the values is null', function() {
   var o = MyObj.create({ value: "Kaylee", label: null });
   strictEqual(o.get('labeled'), null);
+  var oo = MyObj.create({ value: null, label: "Name" });
+  strictEqual(oo.get('labeled'), null);
 });
 
 test('injects multiple values into the format-string', function() {

--- a/tests/unit/macros/fmt-test.js
+++ b/tests/unit/macros/fmt-test.js
@@ -45,3 +45,21 @@ test('recomputes', function() {
   Ember.run(function() {o.set('value', 'Mike');});
   equal(o.get('labeled'), 'First Name: Mike');
 });
+
+test('composeable macro support', function () {
+  var Typ = Ember.Object.extend({
+    firstName: 'Mike',
+    lastName: 'North',
+    language: 'JavaScript',
+    text: fmt(fmt('firstName', 'lastName', '%@ %@'), 'language', 'User %@ likes to write %@')
+  });
+  var obj = Typ.create({});
+
+  strictEqual(obj.get('text'), 'User Mike North likes to write JavaScript');
+  obj.setProperties({
+    firstName: 'Stefan',
+    lastName: 'Penner'
+  });
+  strictEqual(obj.get('text'), 'User Stefan Penner likes to write JavaScript');
+
+});

--- a/tests/unit/macros/fmt-test.js
+++ b/tests/unit/macros/fmt-test.js
@@ -9,13 +9,13 @@ var MyObj = Ember.Object.extend({
 });
 
 test('returns undefined if the value is undefined', function() {
-  var o = MyObj.create();
-  equal(o.get('starred'), undefined);
+  var o = MyObj.create({});
+  strictEqual(o.get('starred'), undefined);
 });
 
 test('returns null if the value is null', function() {
   var o = MyObj.create({ value: null });
-  equal(o.get('starred'), null);
+  strictEqual(o.get('starred'), null);
 });
 
 test('injects the value into the format-string', function() {
@@ -25,12 +25,12 @@ test('injects the value into the format-string', function() {
 
 test('returns undefined if *any* of the values is undefined', function() {
   var o = MyObj.create({ label: "Name" });
-  equal(o.get('labeled'), undefined);
+  strictEqual(o.get('labeled'), undefined);
 });
 
 test('returns null if *any* of the values is null', function() {
-  var o = MyObj.create({ value: "Kaylee" });
-  equal(o.get('labeled'), undefined);
+  var o = MyObj.create({ value: "Kaylee", label: null });
+  strictEqual(o.get('labeled'), null);
 });
 
 test('injects multiple values into the format-string', function() {


### PR DESCRIPTION
I need an extra careful review/discussion here. This PR introduces some inconsistency that doesn't feel right to me.

For previous macros with composeable CPM support, the logic for determining whether a string is a property key or just a string literal value is:

````ruby
given string S
if this.get(S) returns undefined
  #regard S as a string literal value
  return S
else
  #regard S as a property key
  return this.get(S)
````
In essence, we have a bias toward assuming that strings are property keys, which is fine because the developer has `Ember.literal` to remove any ambiguity from string literals.

In the case of `fmt`, there's a test that makes things difficult

```js
var MyObj = Ember.Object.extend({
  starred: fmt('value', '** %@ **'),
  labeled: fmt('label', 'value', '%@: %@')
});

test('returns undefined if *any* of the values is undefined', function() {
  var o = MyObj.create({ label: "Name" });
  strictEqual(o.get('labeled'), undefined);
});

```

Were I to be consistent with `computed`, `product`, `sum`, `quotient`, we would end up with a value of `"Name: value"` due to assuming that "value" is a string literal after finding that `this.get('value')` returns undefined. It's possible that some peoples' code would break if I were to change this behavior.

My solution here is to add a second argument to the "util" method `getVal` -- allowing certain macros to opt-out of assuming string literals in presence of an undefined property value. This means that users MUST use `Ember.literal` for all literals in the fmt macro, whereas it's only required to resolve ambiguous situations in other macros.