### PR TITLE
Make macros that aren't reversible readOnly

### DIFF
--- a/addon/macros/all-equal.js
+++ b/addon/macros/all-equal.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import {getVal, getDependentPropertyKeys} from '../utils';
 
+var computed = Ember.computed;
+
 /**
   Returns true if all the all its dependent values are equal between them.
 
@@ -51,5 +53,5 @@ export default function EmberCPM_allEqual() {
     }
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/among.js
+++ b/addon/macros/among.js
@@ -40,5 +40,5 @@ export default function EmberCPM_among() {
     return false;
   });
 
-  return computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/conditional.js
+++ b/addon/macros/conditional.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
+var computed = Ember.computed;
 /**
    Conditional computed property
 
@@ -29,5 +30,5 @@ export default function EmberCPM_conditional(condition, valIfTrue, valIfFalse) {
     return conditionEvaluation ? valIfTrue : valIfFalse;
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/difference.js
+++ b/addon/macros/difference.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import { getVal, getDependentPropertyKeys } from '../utils';
 
+var computed = Ember.computed;
+
 /**
   Returns the difference between the given elements
 
@@ -35,5 +37,5 @@ export default function EmberCPM_difference() {
     }
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/first-present.js
+++ b/addon/macros/first-present.js
@@ -52,5 +52,5 @@ export default function EmberCPM_firstPresent() {
     if (property) { return get(that, property); }
   });
 
-  return computed.apply(this, computedArgs);
+  return computed.apply(this, computedArgs).readOnly();
 }

--- a/addon/macros/if-null.js
+++ b/addon/macros/if-null.js
@@ -27,5 +27,5 @@ export default function EmberCPM_ifNull(dependentKey, defaultValue) {
     var value = get(this, dependentKey);
 
     return value == null ? defaultValue : value;
-  });
+  }).readOnly();
 }

--- a/addon/macros/join.js
+++ b/addon/macros/join.js
@@ -35,5 +35,5 @@ export default function EmberCPM_join() {
     }).join(separator);
   });
 
-  return cp.property.apply(cp, properties);
+  return cp.property.apply(cp, properties).readOnly();
 }

--- a/addon/macros/mean.js
+++ b/addon/macros/mean.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import { getVal, getDependentPropertyKeys } from '../utils';
 
+var computed = Ember.computed;
+
 /**
   Calculate the arithmetic mean of some numeric properties, numeric literals,
   and/or arrays of numeric properties and literals.
@@ -56,5 +58,5 @@ export default function EmberCPM_mean () {
     return count > 0 ? sum/count : 0;
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/not-among.js
+++ b/addon/macros/not-among.js
@@ -33,5 +33,5 @@ export default function EmberCPM_notAmong(dependentKey) {
     }
 
     return true;
-  });
+  }).readOnly();
 }

--- a/addon/macros/not-equal.js
+++ b/addon/macros/not-equal.js
@@ -23,5 +23,5 @@ export default function EmberCPM_notEqual(dependentKey, targetValue) {
 
   return computed(dependentKey, function(){
     return get(this, dependentKey) !== targetValue;
-  });
+  }).readOnly();
 }

--- a/addon/macros/not-match.js
+++ b/addon/macros/not-match.js
@@ -25,5 +25,5 @@ export default function EmberCPM_notMatch(dependentKey, regexp) {
     var value = get(this, dependentKey);
 
     return typeof value === 'string' ? !value.match(regexp) : true;
-  });
+  }).readOnly();
 }

--- a/addon/macros/not.js
+++ b/addon/macros/not.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import {getDependentPropertyKeys, getVal} from '../utils';
 
+var computed = Ember.computed;
 
 /**
  * not - the boolean inverse of a property or computed property macro
@@ -35,9 +36,18 @@ import {getDependentPropertyKeys, getVal} from '../utils';
 export default function EmberCPM_not (arg) {
   var propertyArguments = getDependentPropertyKeys([arg]);
   Ember.assert('Illegal Argument: ' + arg, 'undefined' !== typeof arg && null !== arg);
-  propertyArguments.push(function () {
-    return 'undefined' !== typeof arg ? !getVal.call(this, arg) : null;
+  propertyArguments.push(function (key, val) {
+    if (arguments.length < 2) {
+      //getter
+      return 'undefined' !== typeof arg ? !getVal.call(this, arg) : null;
+    }
+    else {
+      //setter
+      Ember.assert('EmberCPM.macros.not is not writable if passed inline computed property macros as arguments', Ember.typeOf(arg) === 'string');
+      this.set(arg, !val);
+      return val;
+    }
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments);
 }

--- a/addon/macros/quotient.js
+++ b/addon/macros/quotient.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import {getVal, getDependentPropertyKeys} from '../utils';
 
+var computed = Ember.computed;
+
 /**
   Returns an the float quotient of divide the first argument by the second one.
 
@@ -37,5 +39,5 @@ export default function EmberCPM_quotient() {
     }
   });
 
-  return Ember.computed.apply(this, propertyArguments);
+  return computed.apply(this, propertyArguments).readOnly();
 }

--- a/addon/macros/sum-by.js
+++ b/addon/macros/sum-by.js
@@ -28,5 +28,5 @@ export default function EmberCPM_sumBy(dependentKey, propertyKey) {
     removedItem: function(accumulatedValue, item /*, changeMeta, instanceMeta */){
       return accumulatedValue - parseFloat(get(item, propertyKey));
     }
-  });
+  }).readOnly();
 }

--- a/tests/unit/macros/allEqual-test.js
+++ b/tests/unit/macros/allEqual-test.js
@@ -59,3 +59,9 @@ test('handles composable CPMs', function () {
   myObj.set('b', 4);
   equal(myObj.get('j'), false);
 });
+
+test('attempting to write to the property throws an exception', function () {
+  throws(function () {
+    myObj.set('g', true);
+  });
+});

--- a/tests/unit/macros/among-test.js
+++ b/tests/unit/macros/among-test.js
@@ -84,3 +84,11 @@ test("Numeric values, with numeric computed property macros", function() {
     strictEqual(obj.get('prop'), true);
   });
 });
+
+
+test('attempting to write to the property throws an exception', function () {
+  throws(function () {
+    var show = Show.create({ pet: { name: 'Garfield' } });
+    show.set('hasCartoonDog', true);
+  });
+});

--- a/tests/unit/macros/concat-test.js
+++ b/tests/unit/macros/concat-test.js
@@ -124,3 +124,10 @@ test("concatenates multiple arrays", function() {
 
   deepEqual(obj.get('allPeople').mapProperty('name'), ['Jaime', 'Cersei', 'Robb', 'Eddard', 'Ramsey', 'Roose']);
 });
+
+test('attempting to write to the property throws an exception', function () {
+  throws(function () {
+    obj.set('allPeople', Ember.A([]));
+  });
+
+});

--- a/tests/unit/macros/conditional-test.js
+++ b/tests/unit/macros/conditional-test.js
@@ -131,3 +131,15 @@ test('handles nested conditional computed properties', function () {
   myObj.set('a', 16);
   equal(myObj.get('b'), 'bad');
 });
+
+test('throws exception if written to', function() {
+  var MyType = Ember.Object.extend({
+    a: true,
+    b: conditional('a', 'yes', 'no')
+  });
+
+  var myObj = MyType.create();
+  throws(function () {
+    myObj.set('b');
+  });
+});

--- a/tests/unit/macros/difference-test.js
+++ b/tests/unit/macros/difference-test.js
@@ -51,3 +51,9 @@ test('composable properties case', function () {
   equal(myObj.get('i'), 6);
   myObj.set('a', 6);
 });
+
+test('throws exception if written to', function() {
+  throws(function () {
+    myObj.set('g', 6);
+  });
+});

--- a/tests/unit/macros/first-present-test.js
+++ b/tests/unit/macros/first-present-test.js
@@ -19,3 +19,10 @@ test('returns undefined if all values are empty', function() {
   var obj = Obj.create({ name: '', email: '' });
   equal(obj.get('displayName'), undefined);
 });
+
+test('throws exception if written to', function() {
+  var obj = Obj.create({ name: '', email: '' });
+  throws(function () {
+    obj.set('displayName', 6);
+  });
+});

--- a/tests/unit/macros/if-null-test.js
+++ b/tests/unit/macros/if-null-test.js
@@ -23,3 +23,10 @@ test('returns other falsy values', function() {
   equal(MyObj.create({ value: false }).get('orSushi'), false);
   equal(MyObj.create({ value: 0 }).get('orSushi'), 0);
 });
+
+test('throws exception if written to', function() {
+  var obj = MyObj.create({ value: false });
+  throws(function () {
+    obj.set('orSushi', true);
+  });
+});

--- a/tests/unit/macros/join-test.js
+++ b/tests/unit/macros/join-test.js
@@ -20,3 +20,10 @@ test('updates when dependent properties update', function() {
   obj.set('lastName', 'of Borg');
   equal(obj.get('fullName'), 'Locutus of Borg');
 });
+
+test('throws exception if written to', function() {
+  var obj = Obj.create();
+  throws(function () {
+    obj.set('fullName', 'James T. Kirk');
+  });
+});

--- a/tests/unit/macros/mean-test.js
+++ b/tests/unit/macros/mean-test.js
@@ -72,3 +72,9 @@ test('null case', function () {
 test('undefined case', function () {
   equal(myObj.get('m'), 3);
 });
+
+test('throws exception if written to', function() {
+  throws(function () {
+    myObj.set('n', 6);
+  });
+});

--- a/tests/unit/macros/not-among-test.js
+++ b/tests/unit/macros/not-among-test.js
@@ -16,3 +16,10 @@ test('returns true if the value is not among the given values', function() {
   var o = MyObj.create({ value: 'Garfield' });
   equal(o.get('notCartoonDog'), true);
 });
+
+test('throws exception if written to', function() {
+  var o = MyObj.create({ value: 'Garfield' });
+  throws(function () {
+    o.set('notCartoonDog', true);
+  });
+});

--- a/tests/unit/macros/not-equal-test.js
+++ b/tests/unit/macros/not-equal-test.js
@@ -16,3 +16,10 @@ test('returns true if the value is not equal', function() {
   var o = MyObj.create({ value: 99419 });
   equal(o.get('isNotTwelve'), true);
 });
+
+test('throws exception if written to', function() {
+  var o = MyObj.create({ value: 99419 });
+  throws(function () {
+    o.set('isNotTwelve', true);
+  });
+});

--- a/tests/unit/macros/not-match-test.js
+++ b/tests/unit/macros/not-match-test.js
@@ -31,3 +31,10 @@ test('returns true if the value is a non-string', function() {
   var o = MyObj.create({ movie: { title: 595 } });
   equal(o.get('digitless'), true);
 });
+
+test('throws exception if written to', function() {
+  var o = MyObj.create({ movie: { title: 595 } });
+  throws(function () {
+    o.set('digitless', false);
+  });
+});

--- a/tests/unit/macros/not-test.js
+++ b/tests/unit/macros/not-test.js
@@ -55,3 +55,9 @@ test('Null-argument case', function () {
       });
   }, 'Illegal Argument');
 });
+
+test('is writable, and updates dependant property', function () {
+  strictEqual(myObj.get('val'), false);
+  myObj.set('notValAlias', false);
+  strictEqual(myObj.get('val'), true);
+});

--- a/tests/unit/macros/quotient-test.js
+++ b/tests/unit/macros/quotient-test.js
@@ -50,3 +50,10 @@ test('composable CP support', function () {
   equal(myObj.get('h'), 2.5);
   myObj.set('a', 6);
 });
+
+
+test('throws exception if written to', function() {
+  throws(function () {
+    myObj.set('g', 6);
+  });
+});

--- a/tests/unit/macros/sum-by-test.js
+++ b/tests/unit/macros/sum-by-test.js
@@ -95,3 +95,9 @@ test("can be used on an ArrayProxy itself", function(){
 
   equal(base.get('sum'), 15);
 });
+
+test('throws exception if written to', function() {
+  throws(function () {
+    base.set('sum', 6);
+  });
+});


### PR DESCRIPTION
Macros that perform a "reversible" operation (i.e., "not") can be written in a way that supports reading and writing, but many of the ember-cpm computed property macros do not fit into this category.

I've picked those that seem to be good candidates for `readOnly` and added tests to ensure they throw exceptions in the event of misuse. 
