### PR TITLE
getDependantPropertyKeys bug fixes

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -34,19 +34,22 @@ export function retainByType(arr, type) {
   );
 }
 
-
 export function getDependentPropertyKeys(argumentArr) {
   return argumentArr.reduce(
     function (prev, item) {
       switch (Ember.typeOf(item)) {
         case 'string':
-          prev.push(item);
+          var containsSpaces = item.indexOf(' ') !== -1;
+
+          if(!containsSpaces) {
+            prev.push(item);
+          }
           break;
         case 'boolean':
         case 'number':
           break;
         default:
-          if (item && item.constructor === Ember.Descriptor) {
+          if (item && item.constructor === Ember.Descriptor && item._dependentKeys) {
             prev.pushObjects(item._dependentKeys);
           }
           break;

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
-import { getVal, retainByType } from "ember-cpm/utils";
+import { getVal, retainByType, getDependentPropertyKeys } from "ember-cpm/utils";
+import l from 'ember-cpm/macros/literal';
 
 var MyType = Ember.Object.extend({
   a: 'A',
@@ -48,4 +49,47 @@ test('retain undefined', function () {
 
 test('retain null', function () {
   deepEqual(retainByType(x, 'null'), [null]);
+});
+
+module("utils - getDependentPropertyKeys");
+
+test('an empty array is allowed', function() {
+  deepEqual(getDependentPropertyKeys([]), []);
+});
+
+test('the dependant keys of a computed property are included', function() {
+  var argumentArray = [
+    'a',
+    Ember.computed.alias('dependantKey')
+  ];
+  deepEqual(getDependentPropertyKeys(argumentArray), ['a', 'dependantKey']);
+});
+
+test('literal values are not included', function() {
+  var argumentArray = [
+    'a',
+    l('aLiteralValue'),
+    l('a literal value')
+  ];
+  deepEqual(getDependentPropertyKeys(argumentArray), ['a']);
+});
+
+test('single word keys are included', function() {
+  deepEqual(getDependentPropertyKeys(['a', 'b']), ['a', 'b']);
+});
+
+test('keys with spaces are excluded', function() {
+  deepEqual(getDependentPropertyKeys(['aa', 'bb', 'not valid']), ['aa', 'bb']);
+});
+
+test('keys which are numbers are excluded', function() {
+  deepEqual(getDependentPropertyKeys(['aa', 'bb', 142857]), ['aa', 'bb']);
+});
+
+test('keys which are boolean are excluded', function() {
+  deepEqual(getDependentPropertyKeys(['aa', 'bb', true, false]), ['aa', 'bb']);
+});
+
+test('keys which are null are excluded', function() {
+  deepEqual(getDependentPropertyKeys(['aa', 'bb', null]), ['aa', 'bb']);
 });


### PR DESCRIPTION
This fixes two issues with `getDependantPropertyKeys` and closes https://github.com/cibernox/ember-cpm/issues/103.
#### Keys can now contain spaces

The following no longer raises an exception:

``` javascript
Em.Object.extend({
  fruit: 'blood orange',
  isABloodOrange: allEqual('fruit', 'blood orange')
});
```

![image](https://cloud.githubusercontent.com/assets/2526/4964176/96a3eb10-6745-11e4-865b-4b2cfe449161.png)
#### Literals are now supported

Previously, the following error would be raised:

``` javascript
Em.Object.extend({
  fruit: 'blood orange',
  isABloodOrange: allEqual('fruit', l('blood orange'))
});
```

![image](https://cloud.githubusercontent.com/assets/2526/4966922/3a50a99a-67ed-11e4-851c-cd091a33d11b.png)
