### PR TITLE
remove pkg.main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "doc": "doc",
     "test": "tests"
   },
-  "main": "dist/cjs/ember-cpm.js",
   "scripts": {
     "start": "ember server",
     "build": "ember build",


### PR DESCRIPTION
caught this when upgrading one of our apps to ember-cli#master (soon to be ember 0.2.1)

* it was pointing at non-existent build artifacts
* ember-cli now assumes ember-addons pkg.main (with no ember-addon-main or ember-addon.main) be the entry point for the addon 

[fixes #115]