### PR TITLE
allow summing empty array

### DIFF
--- a/addon/macros/sum.js
+++ b/addon/macros/sum.js
@@ -26,7 +26,7 @@ import {reduceComputedPropertyMacro, getVal} from '../utils';
 
 function singleValueOrArraySum(val) {
   if (Ember.isArray(val)) {
-    return val.reduce(function (prev, item) {return prev + item;});
+    return val.reduce(function (prev, item) {return prev + item;}, 0);
   }
   else {
     return val;

--- a/tests/unit/macros/sum-test.js
+++ b/tests/unit/macros/sum-test.js
@@ -14,7 +14,9 @@ var MyType = Ember.Object.extend({
   k: sum(Ember.computed.max('j'), 5),
   l: sum(sum('a', 'b'), 5),
   m: sum('j'),
-  n: sum('a', 'j', 'j')
+  n: sum('a', 'j', 'j'),
+  o: Ember.A([]),
+  p: sum('o')
 });
 
 var myObj = MyType.create({
@@ -68,4 +70,5 @@ test('calculates the result of a composable computed property involving sum', fu
 test('sums up the items in an array', function (assert) {
   assert.equal(myObj.get('m'), 10);
   assert.equal(myObj.get('n'), 26);
+  assert.equal(myObj.get('p'), 0);
 });


### PR DESCRIPTION
In 2.0.0, using `sum` on a property that contains an empty array throws:

```
Uncaught TypeError: Reduce of empty array with no initial value
```