### PR TITLE
Add computed promise macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ var Macros = {
  * `product` -- multiplies numeric properties and literals together
  * `sum` -- sums numeric properties and literals together
  * `conditional` -- returns values based on a boolean property (good replacement for ternary operator)
+ * `computedPromise` -- Updates computed property when supplied callback (which must return a promise) is resolved
 
 ### Composable Computed Property Macros
 `conditional`, `sum`, `quotient` and `product` have support for *composable* computed property macros. This allows developers to mix other macros together without defining a bunch of otherwise-useless intermediate properties

--- a/addon/index.js
+++ b/addon/index.js
@@ -19,6 +19,7 @@ import difference from './macros/difference';
 import not from './macros/not';
 import asFloat from './macros/as-float';
 import asInt from './macros/as-int';
+import computedPromise from './macros/computed-promise';
 
 function reverseMerge(dest, source) {
   for (var key in source) {
@@ -49,7 +50,8 @@ var Macros = {
   asFloat: asFloat,
   asInt: asInt,
   quotient: quotient,
-  product: product
+  product: product,
+  computedPromise: computedPromise
 };
 var install = function(){ reverseMerge(Ember.computed, Macros); };
 

--- a/addon/macros/computed-promise.js
+++ b/addon/macros/computed-promise.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+
+const { computed } = Ember;
+
+/**
+  Updates computed property when supplied callback (which must return a
+  promise) is resolved.
+
+  Example
+
+  ```javascript
+  data: promiseObject('dep', function(){
+    return ajax('/data.json');
+  })
+
+  myObject.get('data') // => undefined
+
+  // once resolved
+
+  myObject.get('data') // => { foo: 'bar' };
+  ```
+
+  For example, if you have a template that renders `data` when the promise is
+  resolved the template will be updated.
+
+  @method computedPromise
+  @for macros
+  @param *dependentKeys
+  @param callback
+  @returns obj result of callback
+*/
+export default function(...args) {
+  const fn = args.pop();
+
+  if (typeof(fn) !== 'function') {
+    throw new Error('You must supply a function as the last argument to this macro.');
+  }
+
+  const dependentKeys = args.slice();
+  let pendingPromise = false;
+  let result;
+
+  return computed(...dependentKeys, function(key) {
+    if (!pendingPromise) {
+      const promise = fn.call(this);
+      pendingPromise = true;
+
+      Ember.RSVP.resolve(promise)
+        .then((promiseResult) => {
+          result = promiseResult;
+          pendingPromise = false;
+          this.notifyPropertyChange(key);
+        });
+      }
+
+    return result;
+  });
+}

--- a/tests/unit/macros/computed-promise-test.js
+++ b/tests/unit/macros/computed-promise-test.js
@@ -1,0 +1,93 @@
+import { module, test } from "qunit";
+import Ember from "ember";
+import computedPromise from "ember-cpm/macros/computed-promise";
+
+var object;
+var deferred;
+
+module("promise-object", {
+  setup: function(){
+    deferred = Ember.RSVP.defer();
+
+    object = Ember.Object.extend({
+      dep: null,
+      promise: deferred.promise,
+      myComputedPromise: computedPromise('dep', function(){
+        return this.get('promise');
+      })
+    }).create();
+
+  }
+});
+
+test('updates when resolved', function(assert){
+  const done  = assert.async();
+  assert.expect(1);
+
+  // Must kick off promise before we can assert against proper value on next
+  // tick
+  object.get('myComputedPromise');
+
+  deferred.promise.then(function() {
+    assert.equal(object.get('myComputedPromise').foo, 'bar');
+
+    done();
+  });
+
+  deferred.resolve({ foo: 'bar' });
+});
+
+test('when dependent key changes cb is invoked (non-eagerly)', function(assert){
+  const done  = assert.async();
+  assert.expect(2);
+
+  // Must kick off promise before we can assert against proper value on next
+  // tick
+  object.get('myComputedPromise');
+
+  deferred.promise.then(function() {
+    assert.equal(object.get('myComputedPromise').foo, 'bar');
+  }).then(function(){
+    object.set('dep', 'does not matter');
+  }).then(function(){
+    deferred = Ember.RSVP.defer();
+
+    object.set('promise', deferred.promise);
+    object.get('myComputedPromise');
+
+    deferred.resolve({ foo: 'baz' });
+
+    return deferred.promise;
+  }).then(function(){
+    assert.equal(object.get('myComputedPromise').foo, 'baz');
+    done();
+  });
+
+  // kick it all off
+  deferred.resolve({ foo: 'bar' });
+});
+
+test('if fn not last argument throws', function(assert){
+    assert.throws(function(){
+      computedPromise('dep');
+    }, /You must supply a function as the last argument to this macro./);
+});
+
+test('works when not given a cb who returns a promise', function(assert){
+  const done  = assert.async();
+  assert.expect(1);
+
+  object.set('promise', { foo: 'bar' });
+
+  // Must kick off promise before we can assert against proper value on next
+  // tick
+  object.get('myComputedPromise');
+
+  deferred.promise.then(function() {
+    assert.equal(object.get('myComputedPromise').foo, 'bar');
+
+    done();
+  });
+
+  deferred.resolve();
+});


### PR DESCRIPTION
Updates computed property when supplied callback (which must return a promise) is resolved.

Example

```javascript
myObject = Ember.Object.extend({
  data: promiseObject('dep', function(){
    return ajax('/data.json');
  })
})

myObject.get('data') // => undefined

// once resolved

myObject.get('data') // => { foo: 'bar' };
```

For example, if you have a template that renders `data` when the promise is resolved the template will be updated.

/ht @rwjblue (for help / pairing time) :beers: